### PR TITLE
Cookie wouldn't set on the right domain when logging in

### DIFF
--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -70,6 +70,8 @@ export const authenticated = async (req: express.Request): Promise<boolean> => {
       // The password is stored in the cookie after being hashed.
       const hashedPasswordFromArgs = req.args["hashed-password"]
       const passwordMethod = getPasswordMethod(hashedPasswordFromArgs)
+      console.log(">>>>>>>>>>> COOKIE", req.cookies.key)
+      console.log(">>>>>>>>>>> SAN COOKIE", sanitizeString(req.cookies.key))
       const isCookieValidArgs: IsCookieValidArgs = {
         passwordMethod,
         cookieKey: sanitizeString(req.cookies.key),
@@ -130,7 +132,11 @@ export const redirect = (
  * in. This will use the highest level proxy domain (e.g. `coder.com` over
  * `test.coder.com` if both are specified).
  */
-export const getCookieDomain = (host: string, proxyDomains: string[]): string | undefined => {
+export const getCookieDomain = (
+  host: string,
+  proxyDomains: string[],
+  proxyPortSeparator: string,
+): string | undefined => {
   const idx = host.lastIndexOf(":")
   host = idx !== -1 ? host.substring(0, idx) : host
   // If any of these are true we will still set cookies but without an explicit
@@ -162,11 +168,11 @@ export const getCookieDomain = (host: string, proxyDomains: string[]): string | 
   }
 
   proxyDomains.forEach((domain) => {
-    if (host.endsWith(domain) && domain.length < host.length) {
+    if (host.endsWith(domain) && domain.length < host.length && proxyPortSeparator === "dot") {
       host = domain
     }
   })
 
-  logger.debug("got cookie doman", field("host", host))
+  logger.debug("got cookie domain", field("host", host))
   return host || undefined
 }

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -70,8 +70,6 @@ export const authenticated = async (req: express.Request): Promise<boolean> => {
       // The password is stored in the cookie after being hashed.
       const hashedPasswordFromArgs = req.args["hashed-password"]
       const passwordMethod = getPasswordMethod(hashedPasswordFromArgs)
-      console.log(">>>>>>>>>>> COOKIE", req.cookies.key)
-      console.log(">>>>>>>>>>> SAN COOKIE", sanitizeString(req.cookies.key))
       const isCookieValidArgs: IsCookieValidArgs = {
         passwordMethod,
         cookieKey: sanitizeString(req.cookies.key),

--- a/src/node/routes/login.ts
+++ b/src/node/routes/login.ts
@@ -87,7 +87,7 @@ router.post("/", async (req, res) => {
       // The hash does not add any actual security but we do it for
       // obfuscation purposes (and as a side effect it handles escaping).
       res.cookie(Cookie.Key, hashedPassword, {
-        domain: getCookieDomain(req.headers.host || "", req.args["proxy-domain"]),
+        domain: getCookieDomain(req.headers.host || "", req.args["proxy-domain"], req.args["proxy-port-separator"]),
         path: req.body.base || "/",
         sameSite: "lax",
       })

--- a/src/node/routes/logout.ts
+++ b/src/node/routes/logout.ts
@@ -7,7 +7,7 @@ export const router = Router()
 router.get("/", async (req, res) => {
   // Must use the *identical* properties used to set the cookie.
   res.clearCookie(Cookie.Key, {
-    domain: getCookieDomain(req.headers.host || "", req.args["proxy-domain"]),
+    domain: getCookieDomain(req.headers.host || "", req.args["proxy-domain"], req.args["proxy-port-separator"]),
     path: req.query.base || "/",
     sameSite: "lax",
   })


### PR DESCRIPTION
Fixed loop where login to port separated with dash wouldn't set the cookie on the right domain.

3000-user-org.brev.sh would take you to a login page. You'd then have to login. At that point, in `http.ts` in `getCookieDomain` we'd encounter this line that would set the cookie on the base domain without the port (user-org.brev.sh). This worked when the proxy port separator was a dot, but doesn't at all when it's a dash.

Decided to just check if the port separator was dot (added `&& proxyPortSeparator === "dot"`). We can't automatically apply  to subdomains when proxyPortSeparator is "dash" because of cookie inheritance rules.

```
// Old code
proxyDomains.forEach((domain) => {
  if (host.endsWith(domain) && domain.length < host.length) {
    host = domain
  }
})
```

```
// New code
proxyDomains.forEach((domain) => {
  if (host.endsWith(domain) && domain.length < host.length && proxyPortSeparator === "dot") {
    host = domain
  }
})
```